### PR TITLE
add without labels

### DIFF
--- a/src/labeq_exopy/tasks/tasks/util/save_tasks.py
+++ b/src/labeq_exopy/tasks/tasks/util/save_tasks.py
@@ -88,6 +88,7 @@ class SaveTask(SimpleTask):
         """
         print(f'self.file_mode1: {self.file_mode}')
         # Initialisation.
+        
         if not self.initialized:
 
             self.line_index = 0
@@ -121,10 +122,12 @@ class SaveTask(SimpleTask):
                     for line in h.split('\n'):
                         self.file_object.write(('# ' + line +
                                                 '\n').encode('utf-8'))
-                labels = [self.format_string(s) for s in self.saved_values]
-                self.file_object.write(('\t'.join(labels) +
-                                        '\n').encode('utf-8'))
-                self.file_object.flush()
+                
+                if self.file_mode == "New":
+                    labels = [self.format_string(s) for s in self.saved_values]
+                    self.file_object.write(('\t'.join(labels) +
+                                            '\n').encode('utf-8'))
+                    self.file_object.flush()
 
             if self.saving_target != 'File':
                 # TODO add more flexibilty on the dtype (possible complex

--- a/src/labeq_exopy/tasks/tasks/util/views/save_views.enaml
+++ b/src/labeq_exopy/tasks/tasks/util/views/save_views.enaml
@@ -150,6 +150,7 @@ enamldef SaveView(BaseTaskView):
         ed.operations = ('add', 'move', 'remove')
         ed.attributes = {'task': task}
 
+    
 
 enamldef SaveFileView(BaseTaskView):
     """View for the save file task.


### PR DESCRIPTION
SaveTask now will not add data labels to the file when appending. It is assumed that the date values to be saved correspond to the table already in the file. Now, only when 'New' file is selected will col labels be added to the top of the output file.