### PR TITLE
Feature lock in set gain and time const task revisions

### DIFF
--- a/src/labeq_exopy/tasks/tasks/instr/sr810_SetGainAndTimeConst_task.py
+++ b/src/labeq_exopy/tasks/tasks/instr/sr810_SetGainAndTimeConst_task.py
@@ -33,29 +33,29 @@ class LockInSetGainAndTimeConstTask(InstrumentTask):
     #: Values to be selected by the user: Boolean values used with checkbox UI
     AutoGain=Bool(False).tag(pref=True)
 
-    SenseNum_1=Bool(False).tag(pref=True)
+    SenseNum_1=Bool(True).tag(pref=True)
     SenseNum_2=Bool(False).tag(pref=True)
     SenseNum_3=Bool(False).tag(pref=True)
    
-    SenseMult_1=Bool(False).tag(pref=True)
+    SenseMult_1=Bool(True).tag(pref=True)
     SenseMult_2=Bool(False).tag(pref=True)
     SenseMult_3=Bool(False).tag(pref=True)
 
     SenseUnit_1=Bool(False).tag(pref=True)
-    SenseUnit_2=Bool(False).tag(pref=True)
+    SenseUnit_2=Bool(True).tag(pref=True)
     SenseUnit_3=Bool(False).tag(pref=True)
     SenseUnit_4=Bool(False).tag(pref=True)
     
-    TCNum_1=Bool(False).tag(pref=True)
+    TCNum_1=Bool(True).tag(pref=True)
     TCNum_2=Bool(False).tag(pref=True)
     
     TCMult_1=Bool(False).tag(pref=True)
-    TCMult_2=Bool(False).tag(pref=True)
+    TCMult_2=Bool(True).tag(pref=True)
     TCMult_3=Bool(False).tag(pref=True)
     
     TCUnit_1=Bool(False).tag(pref=True)
     TCUnit_2=Bool(False).tag(pref=True)
-    TCUnit_3=Bool(False).tag(pref=True)
+    TCUnit_3=Bool(True).tag(pref=True)
     TCUnit_4=Bool(False).tag(pref=True)
 
 

--- a/src/labeq_exopy/tasks/tasks/instr/sr810_SetGainAndTimeConst_task.py
+++ b/src/labeq_exopy/tasks/tasks/instr/sr810_SetGainAndTimeConst_task.py
@@ -134,9 +134,9 @@ class LockInSetGainAndTimeConstTask(InstrumentTask):
                 SenseMult=10
             elif self.SenseMult_3 == True:
                 SenseMult=100
-            selected_sense=SenseNum*SenseMult*SenseUnit
-        
+
             if SenseUnit != 1:
+                selected_sense=SenseNum*SenseMult*SenseUnit
                 for i in range (0,25):
                     if SenseList[i] == selected_sense:
                         self.driver.set_sense(i)


### PR DESCRIPTION
Fixed initialization errors. Selected_Sense is now only initialized if the sensitivity is not 1V. SenseMult, SenseNum, and SenseUnit now have default initialization values. TCMult, TCNum, and TCUnit also have default initialization values. The values assign a default sensitivity and time constant of 1 mV and 10 ms respectively. The code runs in Exopy with no errors.